### PR TITLE
Make dystonse-gtfs-importer a universal tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
-name = "dystonse-gtfs-importer"
+name = "dystonse-gtfs-tool"
 version = "1.0.0"
 dependencies = [
  "bytes 0.5.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
-name = "dystonse-gtfs-tool"
+name = "dystonse-gtfs-data"
 version = "1.0.0"
 dependencies = [
  "bytes 0.5.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
@@ -419,6 +419,7 @@ dependencies = [
  "gtfs-structures",
  "lazy_static",
  "mysql",
+ "parse_duration",
  "prost",
  "rayon",
  "regex",
@@ -853,9 +854,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical"
-version = "4.2.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaad0ee8120fc0cf7df7e8fdbe79bf9d6189351404feb88f4e4a4bb5307bc594"
+checksum = "0afaeae1c07c575338ef6809875bfea8daa9ea8b2ee381ef1f93ba0c6e32f003"
 dependencies = [
  "cfg-if",
  "lexical-core",
@@ -864,12 +865,11 @@ dependencies = [
 
 [[package]]
 name = "lexical-core"
-version = "0.6.7"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86d66d380c9c5a685aaac7a11818bdfa1f733198dfd9ec09c70b762cd12ad6f"
+checksum = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
 dependencies = [
  "arrayvec",
- "bitflags",
  "cfg-if",
  "rustc_version",
  "ryu",
@@ -1112,6 +1112,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "num"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,12 +1137,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
  "autocfg 1.0.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1188,6 +1235,17 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parse_duration"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc8d8324ba4f571dbac55dea78c76f72681fcc488b51a9ee7ddb10263e7e92ae"
+dependencies = [
+ "lazy_static",
+ "num",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dystonse-gtfs-importer"
+name = "dystonse-gtfs-tool"
 version = "1.0.0"
 authors = ["Lena Schimmel <mail@lenaschimmel.de>", "Kirstin Rohwer <mail@metakiki.net>"]
 edition = "2018"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ lazy_static = "1.4.0"
 retry = "1.0.0"
 simple-error = "0.2.1"
 reqwest = { version = "0.10.4", features = ["blocking"] }
+parse_duration = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "dystonse-gtfs-tool"
+name = "dystonse-gtfs-data"
 version = "1.0.0"
 authors = ["Lena Schimmel <mail@lenaschimmel.de>", "Kirstin Rohwer <mail@metakiki.net>"]
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -39,13 +39,14 @@ In `batch` mode, it works exactly as in `automatic` mode, but the importer exits
 This has currently only one subcommand: `count`.
 
 ### `count` mode
-For a given source id, this will count the number of valid real time entries for each time interval. An entry is consideres valid if its `delay_arrival` is between -10 hours and +10 hours. The whole time span for which there is real time data will be split into parts of length corresponding  to the `interval` parameter, which has a default value of `1h` (one hour).
+For a given source id, this will count the number of valid real time entries for each time interval. An entry is considered valid if its `delay_arrival` is between -10 hours and +10 hours. The whole time span for which there is real time data will be split into parts of length corresponding  to the `interval` parameter, which has a default value of `1h` (one hour).
 
-Simple statistics are output to sdtout as CSV like this (space padding added for clarity, they won't be present in the real output):
+Simple statistics are output to `stdout` as CSV like this (space padding added for clarity, they won't be present in the real output):
 
 ```
-time_min;            time_max;            trip update count; average delay; rt file count; rt file size
-2020-03-16 00:41:02; 2020-03-16 04:41:02;                72;       11.6111;            12;        18279
+time_min;            time_max;            stop_time update count; average delay; rt file count; rt file size
+2020-03-16 00:41:02; 2020-03-16 04:41:02;                     72;       11.6111;            12;        18279
+[...]
 ```
 
 ## Docker integration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Rust crate that works with static gtfs schedules (as zip or directory)
 
 In **import** mode, it matches the realtime data to the schedule data and writes everything into the mysql database.
 
-In **analyse** mode, it does nothing yet, but lots of interesting features are yet to come.
+In **analyse** mode, it can count the data entries per time and output some simple statistics. More features are yet to come.
 
 ## How to use this
 
@@ -36,7 +36,17 @@ In automatic mode:
 In `batch` mode, it works exactly as in `automatic` mode, but the importer exits after step 2.
 
 ## Analysing data
-Nothing to see yet.
+This has currently only one subcommand: `count`.
+
+### `count` mode
+For a given source id, this will count the number of valid real time entries for each time interval. An entry is consideres valid if its `delay_arrival` is between -10 hours and +10 hours. The whole time span for which there is real time data will be split into parts of length corresponding  to the `interval` parameter, which has a default value of `1h` (one hour).
+
+Simple statistics are output to sdtout as CSV like this (space padding added for clarity, they won't be present in the real output):
+
+```
+time_min;            time_max;            trip update count; average delay; rt file count; rt file size
+2020-03-16 00:41:02; 2020-03-16 04:41:02;                72;       11.6111;            12;        18279
+```
 
 ## Docker integration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# dystonse-gtfs-tool
+# dystonse-gtfs-data
 
-This is a Rust crate that works with a static gtfs schedules (as zip or directory), gtfs-realtime data (as .pb or .zip files) and a mysql database (setup info is specified in [dystonse-docker](https://github.com/dystonse/dystonse-docker)) to read, import or anaylse the data.
+This is a Rust crate that works with static gtfs schedules (as zip or directory), gtfs-realtime data (as .pb or .zip files) and a mysql database (setup info is specified in [dystonse-docker](https://github.com/dystonse/dystonse-docker)) to read, import or anaylse the data.
 
 In **import** mode, it matches the realtime data to the schedule data and writes everything into the mysql database.
 
@@ -8,23 +8,23 @@ In **analyse** mode, it does nothing yet, but lots of interesting features are y
 
 ## How to use this
 
-Basic syntax is `dystonse-gtfs-tool [global options] <command> <subcommand> [args]`, or if you run it via cargo, `cargo run [--release] -- [global options] <command> <subcommand> [args]`.
+Basic syntax is `dystonse-gtfs-data [global options] <command> <subcommand> [args]`, or if you run it via cargo, `cargo run [--release] -- [global options] <command> <subcommand> [args]`.
 
 There are a lot of database parameters to be defined globally. Those `DB_…`parameters can either be defined as environment variables (using the upper case names like `DB_PASSWORD`) or as command line parameters (using lower-case variants without the `db`-prefix, e.g. `--password`). Default values are provided for `DB_USER`, `DB_HOST`, `DB_PORT` and `DB_DATABASE`. In contrast, `DB_PASSWORD` and `GTFS_DATA_SOURCE_ID` always have to be specified when running this, where `GTFS_DATA_SOURCE_ID` is a string identifier that will be written as-is into the database for each entry. In the syntax examples below, we use a mix of env vars and command line parameters.
 
-You can also use `dystonse-gtfs-tool [command [subcommand]] --help` to get information about the command syntax.
+You can also use `dystonse-gtfs-data [command [subcommand]] --help` to get information about the command syntax.
 
 ## Importing data
 ### `import manual` mode
 
-`DB_PASSWORD=<password> dystonse-gtfs-tool [-v] --source <source> import manual <gtfs file path> <gfts-rt file path(s)>`
+`DB_PASSWORD=<password> dystonse-gtfs-data [-v] --source <source> import manual <gtfs file path> <gfts-rt file path(s)>`
 
 without `-v`, the only output on stdout is a list of the gtfs-realtime filenames that have been parsed successfully.
 
 ### `import automatic` and `import batch` mode
 Instead of `manual` mode, you can use `automatic` or `batch` mode:
 
-`DB_PASSWORD=<password> dystonse-gtfs-tool -- [-v] --source <source> import automatic <dir>`
+`DB_PASSWORD=<password> dystonse-gtfs-data -- [-v] --source <source> import automatic <dir>`
 
 In automatic mode:
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,30 @@
-# dystonse-gtfs-importer
+# dystonse-gtfs-tool
 
-This is a Rust crate that reads a static gtfs schedule file and any number of gtfs-realtime .pb or .zip files (given as command line arguments), matches the realtime data to the schedule data and writes everything into a mysql database.
+This is a Rust crate that works with a static gtfs schedules (as zip or directory), gtfs-realtime data (as .pb or .zip files) and a mysql database (setup info is specified in [dystonse-docker](https://github.com/dystonse/dystonse-docker)) to read, import or anaylse the data.
+
+In **import** mode, it matches the realtime data to the schedule data and writes everything into the mysql database.
+
+In **analyse** mode, it does nothing yet, but lots of interesting features are yet to come.
 
 ## How to use this
 
-`DB_PASSWORD=<password> cargo run [--release] -- [-v] --source <source> manual <gtfs file path> <gfts-rt file path(s)>`
+Basic syntax is `dystonse-gtfs-tool [global options] <command> <subcommand> [args]`, or if you run it via cargo, `cargo run [--release] -- [global options] <command> <subcommand> [args]`.
 
-A mysql database (setup info is specified in [dystonse-docker](https://github.com/dystonse/dystonse-docker)) needs to be running before you can use this crate.
+There are a lot of database parameters to be defined globally. Those `DB_…`parameters can either be defined as environment variables (using the upper case names like `DB_PASSWORD`) or as command line parameters (using lower-case variants without the `db`-prefix, e.g. `--password`). Default values are provided for `DB_USER`, `DB_HOST`, `DB_PORT` and `DB_DATABASE`. In contrast, `DB_PASSWORD` and `GTFS_DATA_SOURCE_ID` always have to be specified when running this, where `GTFS_DATA_SOURCE_ID` is a string identifier that will be written as-is into the database for each entry. In the syntax examples below, we use a mix of env vars and command line parameters.
 
-The `DB_…`parameters can either be defined as environment variables (using the upper case names like `DB_PASSWORD`) or as command line parameters (using lower-case variants without the `db`-prefix, e.g. `--password`). Default values are provided for `DB_USER`, `DB_HOST`, `DB_PORT` and `DB_DATABASE`. In contrast, `DB_PASSWORD` and `GTFS_DATA_SOURCE_ID` always have to be specified when running this, where `GTFS_DATA_SOURCE_ID` is a string identifier that will be written as-is into the database for each entry.
+You can also use `dystonse-gtfs-tool [command [subcommand]] --help` to get information about the command syntax.
+
+## Importing data
+### `import manual` mode
+
+`DB_PASSWORD=<password> dystonse-gtfs-tool [-v] --source <source> import manual <gtfs file path> <gfts-rt file path(s)>`
 
 without `-v`, the only output on stdout is a list of the gtfs-realtime filenames that have been parsed successfully.
 
-## Automatic mode
+### `import automatic` and `import batch` mode
 Instead of `manual` mode, you can use `automatic` or `batch` mode:
 
-`DB_PASSWORD=<password> cargo run [--release] -- [-v] --source <source> automatic <dir>`
+`DB_PASSWORD=<password> dystonse-gtfs-tool -- [-v] --source <source> import automatic <dir>`
 
 In automatic mode:
 
@@ -24,7 +33,10 @@ In automatic mode:
 3. When all known files are processed, the importer will look for new files that appeared during its operation. If new files are found, it repeats from step 1.
 4. If no new files were found during step 3, the importer will wait for a minute and then continue with step 3.
 
-In batch mode, it works exactly as in automatic mode, but the importer exits after step 2.
+In `batch` mode, it works exactly as in `automatic` mode, but the importer exits after step 2.
+
+## Analysing data
+Nothing to see yet.
 
 ## Docker integration
 

--- a/src/analyser/mod.rs
+++ b/src/analyser/mod.rs
@@ -1,0 +1,37 @@
+use clap::{App, Arg, ArgMatches};
+use crate::FnResult;
+use crate::Main;
+
+pub struct Analyser<'a> {
+    main: &'a Main,
+    args: &'a ArgMatches,
+}
+
+impl<'a> Analyser<'a> {
+    pub fn get_subcommand() -> App<'a> {
+        App::new("analyse")
+    }
+
+    pub fn new(main: &'a Main, args: &'a ArgMatches) -> Analyser<'a> {
+        Analyser {
+            main,
+            args
+        }
+    }
+
+    /// Runs the actions that are selected via the command line args
+    pub fn run(&mut self) -> FnResult<()> {
+        match self.args.clone().subcommand() {
+            // ("automatic", Some(sub_args)) => {
+            //     self.set_dir_paths(sub_args)?;
+            //     self.run_as_non_manual(true)
+            // }
+            // ("batch", Some(sub_args)) => {
+            //     self.set_dir_paths(sub_args)?;
+            //     self.run_as_non_manual(false)
+            // }
+            // ("manual", Some(sub_args)) => self.run_as_manual(sub_args),
+            _ => panic!("Invalid arguments."),
+        }
+    }
+}

--- a/src/analyser/mod.rs
+++ b/src/analyser/mod.rs
@@ -97,7 +97,7 @@ impl<'a> Analyser<'a> {
         let mut time_min = start;
         let mut time_max = start + step;
         println!(
-            "time_min; time_max; trip update count; average delay; rt file count; rt file size"
+            "time_min; time_max; stop time update count; average delay; rt file count; rt file size"
         );
         loop {
             let mut rt_file_count = 0;

--- a/src/analyser/mod.rs
+++ b/src/analyser/mod.rs
@@ -1,8 +1,9 @@
-use clap::{App, Arg, ArgMatches};
+use clap::{App, ArgMatches};
 use crate::FnResult;
 use crate::Main;
 
 pub struct Analyser<'a> {
+    #[allow(dead_code)]
     main: &'a Main,
     args: &'a ArgMatches,
 }

--- a/src/analyser/mod.rs
+++ b/src/analyser/mod.rs
@@ -28,9 +28,7 @@ impl<'a> Analyser<'a> {
                 .help("The directory which contains schedules and realtime data")
                 .long_help(
                     "The directory that contains the schedules (located in a subdirectory named 'schedules') \
-                    and realtime data (located in a subdirectory named 'rt'). \
-                    Successfully processed files are moved to a subdirectory named 'imported'. \
-                    The 'imported' subdirectory will be created automatically if it doesn't already exist."
+                    and realtime data (located in a subdirectory named 'rt')."
                 )
             )
     }

--- a/src/analyser/mod.rs
+++ b/src/analyser/mod.rs
@@ -1,32 +1,55 @@
-use clap::{App, ArgMatches};
+use crate::importer::Importer;
 use crate::FnResult;
 use crate::Main;
+use chrono::NaiveDateTime;
+use clap::{App, Arg, ArgMatches};
+use mysql::prelude::*;
+use mysql::time::Duration;
+use regex::Regex;
+use simple_error::SimpleError;
+use std::fs;
+use std::str::FromStr;
 
 pub struct Analyser<'a> {
     #[allow(dead_code)]
     main: &'a Main,
     args: &'a ArgMatches,
+    data_dir: Option<String>,
 }
 
 impl<'a> Analyser<'a> {
     pub fn get_subcommand() -> App<'a> {
         App::new("analyse")
+            .subcommand(App::new("count"))
+        .arg(Arg::with_name("dir")
+                .index(1)
+                .value_name("DIRECTORY")
+                .required_unless("help")
+                .help("The directory which contains schedules and realtime data")
+                .long_help(
+                    "The directory that contains the schedules (located in a subdirectory named 'schedules') \
+                    and realtime data (located in a subdirectory named 'rt'). \
+                    Successfully processed files are moved to a subdirectory named 'imported'. \
+                    The 'imported' subdirectory will be created automatically if it doesn't already exist."
+                )
+            )
     }
 
     pub fn new(main: &'a Main, args: &'a ArgMatches) -> Analyser<'a> {
         Analyser {
             main,
-            args
+            args,
+            data_dir: Some(String::from(
+                args.value_of("dir")
+                    .unwrap(),
+            )),
         }
     }
 
     /// Runs the actions that are selected via the command line args
     pub fn run(&mut self) -> FnResult<()> {
         match self.args.clone().subcommand() {
-            // ("automatic", Some(sub_args)) => {
-            //     self.set_dir_paths(sub_args)?;
-            //     self.run_as_non_manual(true)
-            // }
+            ("count", Some(_sub_args)) => self.run_count(),
             // ("batch", Some(sub_args)) => {
             //     self.set_dir_paths(sub_args)?;
             //     self.run_as_non_manual(false)
@@ -34,5 +57,74 @@ impl<'a> Analyser<'a> {
             // ("manual", Some(sub_args)) => self.run_as_manual(sub_args),
             _ => panic!("Invalid arguments."),
         }
+    }
+
+    pub fn date_time_from_filename(filename: &str) -> FnResult<NaiveDateTime> {
+        lazy_static! {
+            static ref FIND_DATE: Regex = Regex::new(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})").unwrap(); // can't fail because our hard-coded regex is known to be ok
+        }
+        let date_element_captures =
+            FIND_DATE
+                .captures(&filename)
+                .ok_or(SimpleError::new(format!(
+                "File name does not contain a valid date (does not match format YYYY-MM-DD): {}",
+                filename
+            )))?;
+        Ok(NaiveDateTime::from_str(&date_element_captures[1])?)
+    }
+
+    fn run_count(&self) -> FnResult<()> {
+        let imported_dir = format!("{}/imported", &self.data_dir.as_ref().unwrap());
+        let rt_filenames = Importer::read_dir_simple(&imported_dir)?;
+
+        if rt_filenames.is_empty() {
+            return Err(Box::from(SimpleError::new("No realtime data.")));
+        }
+
+        let mut con = self.main.pool.get_conn()?;
+        let (start, end): (mysql::chrono::NaiveDateTime, mysql::chrono::NaiveDateTime) = con
+            .query_first("SELECT MIN(time_of_recording), MAX(time_of_recording) from realtime")?
+            .unwrap();
+
+        let step = Duration::hours(1);
+        let mut time_min = start;
+        let mut time_max = start + step;
+        println!(
+            "time_min; time_max; trip update count; average delay; rt file count; rt file size"
+        );
+        loop {
+            let mut rt_file_count = 0;
+            let mut rt_file_size = 0;
+            let row : mysql::Row = con.exec_first(
+                "SELECT COUNT(*), AVG(delay_arrival) 
+                FROM realtime 
+                WHERE (`time_of_recording` BETWEEN ? AND ?) 
+                AND (delay_arrival BETWEEN - 36000 AND 36000) 
+                AND source = ?", 
+                (time_min, time_max, &self.main.source))?.unwrap();
+            let count: i32 = row.get(0).unwrap();
+            let delay: f32 = row.get_opt(1).unwrap().unwrap_or(-1.0);
+            // println!("Between {} and {} there are {} delay values, average is {} seconds.", time_min, time_max, count, delay);
+
+            for rt_filename in &rt_filenames {
+                let rt_date = Analyser::date_time_from_filename(&rt_filename).unwrap();
+                if rt_date > time_min && rt_date < time_max {
+                    rt_file_count += 1;
+                    rt_file_size += fs::metadata(&rt_filename)?.len();
+                }
+            }
+
+            println!(
+                "{}; {}; {}; {}; {}; {}",
+                time_min, time_max, count, delay, rt_file_count, rt_file_size
+            );
+            time_min = time_max;
+            time_max = time_min + step;
+            if time_max > end {
+                break;
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/importer/mod.rs
+++ b/src/importer/mod.rs
@@ -23,7 +23,8 @@ pub struct Importer<'a>  {
     main: &'a Main,
     args: &'a ArgMatches,
     rt_dir: Option<String>,
-    schedule_dir: Option<String>,    target_dir: Option<String>,
+    schedule_dir: Option<String>,
+    target_dir: Option<String>,
     fail_dir: Option<String>,
     verbose: bool
 }

--- a/src/importer/mod.rs
+++ b/src/importer/mod.rs
@@ -1,0 +1,507 @@
+mod per_schedule_importer;
+
+use gtfs_structures::Gtfs;
+use mysql::*;
+use simple_error::SimpleError;
+use clap::{App, Arg, ArgMatches};
+use chrono::NaiveDate;
+use rayon::prelude::*;
+use regex::Regex;
+use std::fs;
+use std::fs::DirBuilder;
+use std::path::{Path, PathBuf};
+use std::{thread, time};
+
+use crate::FnResult;
+use crate::Main;
+
+use per_schedule_importer::PerScheduleImporter;
+
+const TIME_BETWEEN_DIR_SCANS: time::Duration = time::Duration::from_secs(60);
+
+pub struct Importer<'a>  {
+    main: &'a Main,
+    args: &'a ArgMatches,
+    target_dir: Option<String>,
+    fail_dir: Option<String>,
+    verbose: bool
+}
+
+
+impl<'a> Importer<'a>  {
+    pub fn get_subcommand() -> App<'a> {
+        App::new("import")
+            .about("Combines data from GTFS schedules and GTFS realtime files and writes them into a database.")
+            .subcommand(App::new("automatic")
+                .about("Runs forever, importing all files which are present or become present during the run.")
+                .arg(Arg::with_name("dir")
+                    .index(1)
+                    .value_name("DIRECTORY")
+                    .required_unless("help")
+                    .help("The directory which contains schedules and realtime data")
+                    .long_help(
+                        "The directory that contains the schedules (located in a subdirectory named 'schedules') \
+                        and realtime data (located in a subdirectory named 'rt'). \
+                        Successfully processed files are moved to a subdirectory named 'imported'. \
+                        The 'imported' subdirectory will be created automatically if it doesn't already exist."
+                    )
+                ).arg(Arg::with_name("pingurl")
+                    .long("pingurl")
+                    .env("PING_URL")
+                    .takes_value(true)
+                    .help("An URL that will be pinged (using HTTP GET) after each iteration.")
+                )
+            )
+            .subcommand(App::new("batch")
+                .about("Imports all files which are present at the time it is started.")
+                .arg(Arg::with_name("dir")
+                    .index(1)
+                    .value_name("DIRECTORY")
+                    .required_unless("help")
+                    .help("The directory which contains schedules and realtime data")
+                    .long_help(
+                        "The directory that contains the schedules (located in a subdirectory named 'schedules') \
+                        and realtime data (located in a subdirectory named 'rt'). \
+                        Successfully processed files are moved to a subdirectory named 'imported'. \
+                        The 'imported' subdirectory will be created automatically if it doesn't already exist."
+                    )
+                )
+            )
+            .subcommand(App::new("manual")
+                .about("Imports all specified realtime files using one specified schedule. Paths to schedule and realtime files have to be given as arguments.")
+                .arg(Arg::with_name("schedule")
+                    .index(1)
+                    .value_name("SCHEDULE")
+                    .help("The static GTFS schedule, as directory or .zip")
+                    .required_unless("help")
+                ).arg(Arg::with_name("rt")
+                    .index(2)
+                    .multiple(true)
+                    .value_name("PBs")
+                    .help("One or more files with real time data, as .pb or .zip")
+                    .required_unless("help")
+                )
+            )
+    }
+
+    pub fn new(main: &'a Main, args: &'a ArgMatches) -> Importer<'a> {
+        Importer {
+            main,
+            args,
+            target_dir: None,
+            fail_dir: None,
+            verbose: main.verbose
+        }
+    }
+
+    /// Runs the actions that are selected via the command line args
+    pub fn run(&mut self) -> FnResult<()> {
+        match self.args.clone().subcommand() {
+            ("automatic", Some(sub_args)) => {
+                self.set_dir_paths(sub_args)?;
+                self.run_as_non_manual(true)
+            }
+            ("batch", Some(sub_args)) => {
+                self.set_dir_paths(sub_args)?;
+                self.run_as_non_manual(false)
+            }
+            ("manual", Some(sub_args)) => self.run_as_manual(sub_args),
+            _ => panic!("Invalid arguments."),
+        }
+    }
+
+    /// Handle manual mode
+    fn run_as_manual(&self, args: &ArgMatches) -> FnResult<()> {
+        let gtfs_schedule_filename = args.value_of("schedule").unwrap(); // already validated by clap
+        let gtfs_realtime_filenames: Vec<String> = args
+            .values_of("rt")
+            .unwrap() // already validated by clap
+            .map(|s| String::from(s))
+            .collect();
+        let statistics = match 
+            self.process_schedule_and_realtimes(&gtfs_schedule_filename, &gtfs_realtime_filenames) {
+                Ok(tuple) => ((1, 1), tuple.0, tuple.1, tuple.2),
+                Err(e) => {
+                    eprintln!("Error while processing schedule and realtimes: {}.", e);
+                    ((1, 0), (0, 0), (0, 0), (0, 0))
+                }
+            };
+        self.output_statistics(statistics);
+
+        Ok(())
+    }
+
+    fn output_statistics(&self, statistics: ((u32, u32), (u32, u32), (u32, u32), (u32, u32))) {
+        if self.verbose {
+            println!("Finished processing files.");
+            println!(
+                "Schedule files   : {} of {} successful.",
+                (statistics.0).1,
+                (statistics.0).0
+            );
+            println!(
+                "Realtime files   : {} of {} successful.",
+                (statistics.1).1,
+                (statistics.1).0
+            );
+            println!(
+                "Trip updates     : {} of {} successful.",
+                (statistics.2).1,
+                (statistics.2).0
+            );
+            println!(
+                "Stop time updates: {} of {} successful.",
+                (statistics.3).1,
+                (statistics.3).0
+            );
+        }
+    }
+
+    /// Reads contents of the given directory and returns an alphabetically sorted list of included files / subdirectories as Vector of Strings.
+    fn read_dir_simple(path: &str) -> FnResult<Vec<String>> {
+        let mut path_list: Vec<String> = fs::read_dir(path)?
+            .filter_map(|r| r.ok()) // unwraps Options and ignores any None values
+            .map(|d| {
+                String::from(d.path().to_str().expect(&format!(
+                    "Found file with invalid UTF8 in file name in directory {}.",
+                    &path
+                )))
+            })
+            .collect();
+        path_list.sort();
+        Ok(path_list)
+    }
+
+    fn date_from_filename(filename: &str) -> FnResult<NaiveDate> {
+        lazy_static! {
+            static ref FIND_DATE: Regex = Regex::new(r"(\d{4})-(\d{2})-(\d{2})").unwrap(); // can't fail because our hard-coded regex is known to be ok
+        }
+        let date_element_captures =
+            FIND_DATE
+                .captures(&filename)
+                .ok_or(SimpleError::new(format!(
+                "File name does not contain a valid date (does not match format YYYY-MM-DD): {}",
+                filename
+            )))?;
+        let date_option = NaiveDate::from_ymd_opt(
+            date_element_captures[1].parse().unwrap(), // can't fail because input string is known to be a bunch of decimal digits
+            date_element_captures[2].parse().unwrap(), // can't fail because input string is known to be a bunch of decimal digits
+            date_element_captures[3].parse().unwrap(), // can't fail because input string is known to be a bunch of decimal digits
+        );
+        Ok (date_option.ok_or(SimpleError::new(format!("File name does not contain a valid date (format looks ok, but values are out of bounds): {}", filename)))?)
+    }
+
+    /// Construct the full directory paths used for storing input files and processed files
+    /// needs the dir argument, this means it can only be used when running in non manual modes
+    fn set_dir_paths(&mut self, args: &ArgMatches) -> FnResult<()> {
+        // construct paths of directories
+        let dir = args.value_of("dir").unwrap(); // already validated by clap
+        self.target_dir = Some(format!("{}/imported", dir));
+        self.fail_dir = Some(format!("{}/failed", dir));
+        Ok(())
+    }
+
+    fn ping_url(&self) {
+        lazy_static! {
+            static ref HTTP_CLIENT: reqwest::blocking::Client = reqwest::blocking::Client::builder()
+            .timeout(time::Duration::from_secs(10))
+            .build().expect("Error while initializing http client.");
+        }
+
+        
+        if let Some(url) = self.args.subcommand_matches("automatic").unwrap().value_of("pingurl") {
+            if self.verbose {
+                println!("Pinging URL {}", url);
+            }
+            if let Err(e) = HTTP_CLIENT.get(url).send() {
+                eprintln!("Error while pinging url {}: {}", url, e);
+            }
+        }
+    }
+
+    /// Handle automatic mode and batch mode, which are very similar to each other
+    fn run_as_non_manual(&self, is_automatic: bool) -> FnResult<()> {
+        // ensure that the directory exists
+        let mut builder = DirBuilder::new();
+        builder.recursive(true);
+        builder.create(self.target_dir.as_ref().unwrap())?; // if target dir can't be created, there's no good way to continue execution
+        builder.create(self.fail_dir.as_ref().unwrap())?; // if fail dir can't be created, there's no good way to continue execution
+        if is_automatic {
+            loop {
+                match self.process_all_files() {
+                    Ok(_) => {
+                        if self.verbose {
+                            println!("Finished one iteration. Sleeping until next directory scan.");
+                        }
+                    }
+                    Err(e) => eprintln!(
+                        "Iteration failed with error: {}. Sleeping until next directory scan.",
+                        e
+                    ),
+                }
+                self.ping_url();
+
+                thread::sleep(TIME_BETWEEN_DIR_SCANS);
+            }
+        } else {
+            match self.process_all_files() {
+                Ok(_) => {
+                    if self.verbose {
+                        println!("Finished.");
+                    }
+                }
+                Err(e) => eprintln!("Failed with error: {}.", e),
+            }
+
+            return Ok(());
+        }
+    }
+
+    fn process_all_files(&self) -> FnResult<()> {
+        if self.verbose {
+            println!("Scan directory");
+        }
+        // list files in both directories
+        let mut schedule_filenames = Importer::read_dir_simple(&self.main.schedule_dir.as_ref().unwrap())?;
+        let rt_filenames = Importer::read_dir_simple(&self.main.rt_dir.as_ref().unwrap())?;
+
+        if rt_filenames.is_empty() {
+            return Err(Box::from(SimpleError::new("No realtime data.")));
+        }
+
+        if schedule_filenames.is_empty() {
+            return Err(Box::from(SimpleError::new(
+                "No schedule data (but real time data is present).",
+            )));
+        }
+
+        // get the date of the earliest schedule, then reverse the list to start searching with the latest schedule
+        let oldest_schedule_date = Importer::date_from_filename(&schedule_filenames[0])?;
+        schedule_filenames.reverse();
+
+        // data structures to collect the files to work on in the current iteration (one schedule and all its corresponding rt files)
+        let mut current_schedule_file = String::new();
+        let mut realtime_files_for_current_schedule: Vec<String> = Vec::new();
+
+        let mut schedules_count = 0;
+        let mut schedules_success_count = 0;
+        let mut real_time_files_count = 0;
+        let mut real_time_files_success_count = 0;
+        let mut trip_updates_count = 0;
+        let mut trip_updates_success_count = 0;
+        let mut stop_time_updates_count = 0;
+        let mut stop_time_updates_success_count = 0;
+
+        // Iterate over all rt files (oldest first), collecting all rt files that belong to the same schedule to process them in batch.
+        for rt_filename in rt_filenames {
+            let rt_date = match Importer::date_from_filename(&rt_filename) {
+                Ok(date) => date,
+                Err(e) => {
+                    match &self.fail_dir {
+                        Some(d) => {
+                            Importer::move_file_to_dir(&rt_filename, &d)?;
+                            eprintln!("Rt file {} does not contain a valid date and was moved to {}. (Error was {})", rt_filename, d, e);
+                        }
+                        None => eprintln!(
+                            "Rt file {} does not contain a valid date. (Error was {})",
+                            rt_filename, e
+                        ),
+                    }
+                    real_time_files_count += 1;
+                    continue;
+                }
+            };
+
+            if rt_date <= oldest_schedule_date {
+                eprintln!(
+                    "Realtime data {} is older than any schedule, skipping.",
+                    rt_filename
+                );
+                // Don't increment count because this is not really a problem, 
+                // and because we don't move those files into fail_dir,
+                // we would count them as an error over and over again.
+                // real_time_files_count += 1;
+                continue;
+            }
+
+            // Look at all schedules (newest first)
+            for schedule_filename in &schedule_filenames {
+                let schedule_date = match Importer::date_from_filename(&schedule_filename) {
+                    Ok(date) => date,
+                    Err(e) => {
+                        match &self.fail_dir {
+                            Some(d) => {
+                                Importer::move_file_to_dir(schedule_filename, &d)?;
+                                eprintln!("Schedule file {} does not contain a valid date and was moved to {}. (Error was {})", schedule_filename, d, e);
+                            }
+                            None => eprintln!(
+                                "Schedule file {} does not contain a valid date. (Error was {})",
+                                schedule_filename, e
+                            ),
+                        }
+                        continue;
+                    }
+                };
+                // Assume we found the right schedule if this is the newest schedule that is older than the realtime file:
+                if rt_date > schedule_date {
+                    // process the current schedule's collection before going to next schedule
+                    if *schedule_filename != current_schedule_file {
+                        if !realtime_files_for_current_schedule.is_empty() {
+                            schedules_count += 1;
+                            match self.process_schedule_and_realtimes(
+                                &current_schedule_file,
+                                &realtime_files_for_current_schedule,
+                            ) {
+                                Ok(((rtc, rtsc), (tuc, tusc), (stuc, stusc))) => {
+                                    schedules_success_count += 1;
+                                    real_time_files_count += rtc;
+                                    real_time_files_success_count += rtsc;
+                                    trip_updates_count += tuc;
+                                    trip_updates_success_count += tusc;
+                                    stop_time_updates_count += stuc;
+                                    stop_time_updates_success_count += stusc;
+                                }
+                                Err(e) => eprintln!(
+                                    "Error in schedule file {}: {}",
+                                    current_schedule_file, e
+                                ),
+                            };
+                        }
+                        // go on with the next schedule
+                        current_schedule_file = schedule_filename.clone();
+                        realtime_files_for_current_schedule.clear();
+                    }
+                    realtime_files_for_current_schedule.push(rt_filename.clone());
+                    // Correct schedule found for this one, so continue with next realtime file
+                    break;
+                }
+            }
+        }
+
+        // process last schedule's collection
+        if !realtime_files_for_current_schedule.is_empty() {
+            schedules_count += 1;
+            match self.process_schedule_and_realtimes(
+                &current_schedule_file,
+                &realtime_files_for_current_schedule,
+            ) {
+                Ok(((rtc, rtsc), (tuc, tusc), (stuc, stusc))) => {
+                    schedules_success_count += 1;
+                    real_time_files_count += rtc;
+                    real_time_files_success_count += rtsc;
+                    trip_updates_count += tuc;
+                    trip_updates_success_count += tusc;
+                    stop_time_updates_count += stuc;
+                    stop_time_updates_success_count += stusc;
+                }
+                Err(e) => eprintln!("Error in schedule file {}: {}", current_schedule_file, e),
+            };
+        }
+        self.output_statistics((
+            (schedules_count, schedules_success_count),
+            (real_time_files_count, real_time_files_success_count),
+            (trip_updates_count, trip_updates_success_count),
+            (stop_time_updates_count, stop_time_updates_success_count),
+        ));
+        Ok(())
+    }
+
+    /// Perform the import of one or more realtime data sets relating to a single schedule
+    fn process_schedule_and_realtimes(
+        &self,
+        gtfs_schedule_filename: &str,
+        gtfs_realtime_filenames: &Vec<String>,
+    ) -> FnResult<((u32, u32), (u32, u32), (u32, u32))> {
+        if self.verbose {
+            println!("Parsing schedule…");
+        }
+
+        let schedule = match Gtfs::new(gtfs_schedule_filename) {
+            Ok(schedule) => schedule,
+            Err(e) => {
+                match &self.fail_dir {
+                    Some(d) => {
+                        Importer::move_file_to_dir(gtfs_schedule_filename, &d)?;
+                        eprintln!("Schedule file {} could not be parsed and was moved to {}. (Error was {})", gtfs_schedule_filename, d, e);
+                    }
+                    None => eprintln!(
+                        "Schedule file {} could not be parsed. (Error was {})",
+                        gtfs_schedule_filename, e
+                    ),
+                }
+                return Err(Box::from(SimpleError::new(
+                    "Schedule file could not be parsed.",
+                )));
+            }
+        };
+
+        if self.verbose {
+            println!("Importing realtime data…");
+        }
+        // create importer for this schedule and iterate over all given realtime files
+        let imp = PerScheduleImporter::new(&schedule, &self.main.pool, self.verbose, &self.main.source);
+
+        let (rt, tu, stu) = gtfs_realtime_filenames
+            .par_iter()
+            .map(|gtfs_realtime_filename| {
+                match self.process_realtime(&gtfs_realtime_filename, &imp) {
+                    Ok(tuple) => ((1,1), tuple.0, tuple.1),
+                    Err(e) => {
+                        eprintln!("Error while reading {}: {}", &gtfs_realtime_filename, e);
+                        ((1, 0), (0, 0), (0, 0))
+                    }
+                }
+            })
+            .reduce(
+                || ((0, 0), (0, 0), (0, 0)),
+                |a, b| {
+                    (
+                        ((a.0).0 + (b.0).0, (a.0).1 + (b.0).1),
+                        ((a.1).0 + (b.1).0, (a.1).1 + (b.1).1),
+                        ((a.2).0 + (b.2).0, (a.2).1 + (b.2).1),
+                    )
+                },
+            );
+        if self.verbose {
+            println!("Done!");
+        }
+        Ok((rt, tu, stu))
+    }
+
+    /// Process a single realtime file on the given Importer
+    fn process_realtime(
+        &self,
+        gtfs_realtime_filename: &str,
+        imp: &PerScheduleImporter,
+    ) -> FnResult<((u32, u32), (u32, u32))> {
+        let statistics = match imp.import_realtime_into_database(&gtfs_realtime_filename) {
+            Ok(s) => s,
+            Err(e) => {
+                // Don't print the error, because it will be handled by the calling function
+                eprintln!("Error in realtime file, moving to fail_dir…");
+                if let Some(dir) = &self.fail_dir {
+                    Importer::move_file_to_dir(gtfs_realtime_filename, &dir)?;
+                }
+                return Err(e);
+            }
+        };
+        // TODO possibly make an error file per failed file to capture the error in place
+        if self.verbose {
+            println!("Finished importing file: {}", &gtfs_realtime_filename);
+        } else {
+            println!("{}", &gtfs_realtime_filename);
+        }
+        // move file into target_dir if target_dir is defined
+        if let Some(dir) = &self.target_dir {
+            Importer::move_file_to_dir(gtfs_realtime_filename, &dir)?;
+        }
+        Ok(statistics)
+    }
+
+    fn move_file_to_dir(filename: &str, dir: &String) -> FnResult<()> {
+        let mut target_path = PathBuf::from(dir);
+        target_path.push(Path::new(&filename).file_name().unwrap()); // assume that the filename does not end in `..` because we got it from a directory listing
+        std::fs::rename(filename, target_path)?;
+        Ok(())
+    }
+}

--- a/src/importer/per_schedule_importer.rs
+++ b/src/importer/per_schedule_importer.rs
@@ -13,7 +13,8 @@ use crate::FnResult;
 
 const MAX_BATCH_SIZE: usize = 1000;
 
-pub struct Importer<'a> {
+
+pub struct PerScheduleImporter<'a> {
     pool: &'a Pool,
     gtfs_schedule: &'a Gtfs,
     verbose: bool,
@@ -51,14 +52,14 @@ struct BatchedInsertions<'a> {
     statement: Statement,
 }
 
-impl<'a> Importer<'a> {
+impl<'a> PerScheduleImporter<'a> {
     pub fn new(
         gtfs_schedule: &'a Gtfs,
         pool: &'a Pool,
         verbose: bool,
         source: &'a str,
-    ) -> Importer<'a> {
-        Importer {
+    ) -> PerScheduleImporter<'a> {
+        PerScheduleImporter {
             gtfs_schedule,
             pool,
             verbose,
@@ -212,14 +213,14 @@ impl<'a> Importer<'a> {
             99
         };
 
-        let arrival = Importer::handle_stop_time_update(
+        let arrival = PerScheduleImporter::handle_stop_time_update(
             stop_time_update.arrival,
             start_date,
             EventType::Arrival,
             &schedule_trip,
             stop_sequence,
         );
-        let departure = Importer::handle_stop_time_update(
+        let departure = PerScheduleImporter::handle_stop_time_update(
             stop_time_update.departure,
             start_date,
             EventType::Departure,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,39 +1,29 @@
-use simple_error::SimpleError;
+mod importer;
+mod analyser;
+
 use std::error::Error;
-use std::fs;
-use std::fs::DirBuilder;
-use std::path::{Path, PathBuf};
-use std::{thread, time};
 #[macro_use]
 extern crate lazy_static;
 
-use chrono::NaiveDate;
 use clap::{App, Arg, ArgMatches};
-use gtfs_structures::Gtfs;
 use mysql::*;
-use rayon::prelude::*;
-use regex::Regex;
 use retry::delay::Fibonacci;
 use retry::retry;
 
-mod importer;
 use importer::Importer;
+use analyser::Analyser;
 
 // This is handy, because mysql defines its own Result type and we don't
 // want to repeat std::result::Result
 type FnResult<R> = std::result::Result<R, Box<dyn Error>>;
 
-const TIME_BETWEEN_DIR_SCANS: time::Duration = time::Duration::from_secs(60);
-
-struct Main {
+pub struct Main {
     verbose: bool,
     pool: Pool,
     args: ArgMatches,
     source: String,
     schedule_dir: Option<String>,
     rt_dir: Option<String>,
-    target_dir: Option<String>,
-    fail_dir: Option<String>,
 }
 
 fn main() -> FnResult<()> {
@@ -43,57 +33,10 @@ fn main() -> FnResult<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    let matches = App::new("Dystonse GTFS Importer")
-        .subcommand(App::new("automatic")
-            .about("Runs forever, importing all files which are present or become present during the run.")
-            .arg(Arg::with_name("dir")
-                .index(1)
-                .value_name("DIRECTORY")
-                .required_unless("help")
-                .help("The directory which contains schedules and realtime data")
-                .long_help(
-                    "The directory that contains the schedules (located in a subdirectory named 'schedules') \
-                    and realtime data (located in a subdirectory named 'rt'). \
-                    Successfully processed files are moved to a subdirectory named 'imported'. \
-                    The 'imported' subdirectory will be created automatically if it doesn't already exist."
-                )
-            ).arg(Arg::with_name("pingurl")
-                .long("pingurl")
-                .env("PING_URL")
-                .takes_value(true)
-                .help("An URL that will be pinged (using HTTP GET) after each iteration.")
-            )
-        )
-        .subcommand(App::new("batch")
-            .about("Imports all files which are present at the time it is started.")
-            .arg(Arg::with_name("dir")
-                .index(1)
-                .value_name("DIRECTORY")
-                .required_unless("help")
-                .help("The directory which contains schedules and realtime data")
-                .long_help(
-                    "The directory that contains the schedules (located in a subdirectory named 'schedules') \
-                    and realtime data (located in a subdirectory named 'rt'). \
-                    Successfully processed files are moved to a subdirectory named 'imported'. \
-                    The 'imported' subdirectory will be created automatically if it doesn't already exist."
-                )
-            )
-        )
-        .subcommand(App::new("manual")
-            .about("Imports all specified realtime files using one specified schedule. Paths to schedule and realtime files have to be given as arguments.")
-            .arg(Arg::with_name("schedule")
-                .index(1)
-                .value_name("SCHEDULE")
-                .help("The static GTFS schedule, as directory or .zip")
-                .required_unless("help")
-            ).arg(Arg::with_name("rt")
-                .index(2)
-                .multiple(true)
-                .value_name("PBs")
-                .help("One or more files with real time data, as .pb or .zip")
-                .required_unless("help")
-            )
-        ).arg(Arg::with_name("verbose")
+    let matches = App::new("Dystonse GTFS Tool")
+        .subcommand(Importer::get_subcommand())
+        .subcommand(Analyser::get_subcommand())
+        .arg(Arg::with_name("verbose")
             .short('v')
             .long("verbose")
             .help("Output status messages during run.")
@@ -163,9 +106,22 @@ impl Main {
             source,
             schedule_dir: None,
             rt_dir: None,
-            target_dir: None,
-            fail_dir: None,
         })
+    }
+
+    /// Runs the actions that are selected via the command line args
+    fn run(&mut self) -> FnResult<()> {
+        match self.args.clone().subcommand() {
+            ("import", Some(sub_args)) => {
+                let mut importer = Importer::new(&self, sub_args);
+                importer.run()
+            }
+            ("analyse", Some(sub_args)) => {
+                let mut analyser = Analyser::new(&self, sub_args);
+                analyser.run()
+            }
+            _ => panic!("Invalid arguments."),
+        }
     }
 
     /// Opens a connection to a database and returns the resulting connection pool.
@@ -187,416 +143,4 @@ impl Main {
         Ok(pool)
     }
 
-    /// Runs the actions that are selected via the command line args
-    fn run(&mut self) -> FnResult<()> {
-        match self.args.clone().subcommand() {
-            ("automatic", Some(sub_args)) => {
-                self.set_dir_paths(sub_args)?;
-                self.run_as_non_manual(true)
-            }
-            ("batch", Some(sub_args)) => {
-                self.set_dir_paths(sub_args)?;
-                self.run_as_non_manual(false)
-            }
-            ("manual", Some(sub_args)) => self.run_as_manual(sub_args),
-            _ => panic!("Invalid arguments."),
-        }
-    }
-
-    /// Handle manual mode
-    fn run_as_manual(&self, args: &ArgMatches) -> FnResult<()> {
-        let gtfs_schedule_filename = args.value_of("schedule").unwrap(); // already validated by clap
-        let gtfs_realtime_filenames: Vec<String> = args
-            .values_of("rt")
-            .unwrap() // already validated by clap
-            .map(|s| String::from(s))
-            .collect();
-        let statistics = match 
-            self.process_schedule_and_realtimes(&gtfs_schedule_filename, &gtfs_realtime_filenames) {
-                Ok(tuple) => ((1, 1), tuple.0, tuple.1, tuple.2),
-                Err(e) => {
-                    eprintln!("Error while processing schedule and realtimes: {}.", e);
-                    ((1, 0), (0, 0), (0, 0), (0, 0))
-                }
-            };
-        self.output_statistics(statistics);
-
-        Ok(())
-    }
-
-    fn output_statistics(&self, statistics: ((u32, u32), (u32, u32), (u32, u32), (u32, u32))) {
-        if self.verbose {
-            println!("Finished processing files.");
-            println!(
-                "Schedule files   : {} of {} successful.",
-                (statistics.0).1,
-                (statistics.0).0
-            );
-            println!(
-                "Realtime files   : {} of {} successful.",
-                (statistics.1).1,
-                (statistics.1).0
-            );
-            println!(
-                "Trip updates     : {} of {} successful.",
-                (statistics.2).1,
-                (statistics.2).0
-            );
-            println!(
-                "Stop time updates: {} of {} successful.",
-                (statistics.3).1,
-                (statistics.3).0
-            );
-        }
-    }
-
-    /// Reads contents of the given directory and returns an alphabetically sorted list of included files / subdirectories as Vector of Strings.
-    fn read_dir_simple(path: &str) -> FnResult<Vec<String>> {
-        let mut path_list: Vec<String> = fs::read_dir(path)?
-            .filter_map(|r| r.ok()) // unwraps Options and ignores any None values
-            .map(|d| {
-                String::from(d.path().to_str().expect(&format!(
-                    "Found file with invalid UTF8 in file name in directory {}.",
-                    &path
-                )))
-            })
-            .collect();
-        path_list.sort();
-        Ok(path_list)
-    }
-
-    fn date_from_filename(filename: &str) -> FnResult<NaiveDate> {
-        lazy_static! {
-            static ref FIND_DATE: Regex = Regex::new(r"(\d{4})-(\d{2})-(\d{2})").unwrap(); // can't fail because our hard-coded regex is known to be ok
-        }
-        let date_element_captures =
-            FIND_DATE
-                .captures(&filename)
-                .ok_or(SimpleError::new(format!(
-                "File name does not contain a valid date (does not match format YYYY-MM-DD): {}",
-                filename
-            )))?;
-        let date_option = NaiveDate::from_ymd_opt(
-            date_element_captures[1].parse().unwrap(), // can't fail because input string is known to be a bunch of decimal digits
-            date_element_captures[2].parse().unwrap(), // can't fail because input string is known to be a bunch of decimal digits
-            date_element_captures[3].parse().unwrap(), // can't fail because input string is known to be a bunch of decimal digits
-        );
-        Ok (date_option.ok_or(SimpleError::new(format!("File name does not contain a valid date (format looks ok, but values are out of bounds): {}", filename)))?)
-    }
-
-    /// Construct the full directory paths used for storing input files and processed files
-    /// needs the dir argument, this means it can only be used when running in non manual modes
-    fn set_dir_paths(&mut self, args: &ArgMatches) -> FnResult<()> {
-        // construct paths of directories
-        let dir = args.value_of("dir").unwrap(); // already validated by clap
-        self.schedule_dir = Some(format!("{}/schedule", dir));
-        self.rt_dir = Some(format!("{}/rt", dir));
-        self.target_dir = Some(format!("{}/imported", dir));
-        self.fail_dir = Some(format!("{}/failed", dir));
-        Ok(())
-    }
-
-    fn ping_url(&self) {
-        lazy_static! {
-            static ref HTTP_CLIENT: reqwest::blocking::Client = reqwest::blocking::Client::builder()
-            .timeout(time::Duration::from_secs(10))
-            .build().expect("Error while initializing http client.");
-        }
-
-        
-        if let Some(url) = self.args.subcommand_matches("automatic").unwrap().value_of("pingurl") {
-            if self.verbose {
-                println!("Pinging URL {}", url);
-            }
-            if let Err(e) = HTTP_CLIENT.get(url).send() {
-                eprintln!("Error while pinging url {}: {}", url, e);
-            }
-        }
-    }
-
-    /// Handle automatic mode and batch mode, which are very similar to each other
-    fn run_as_non_manual(&self, is_automatic: bool) -> FnResult<()> {
-        // ensure that the directory exists
-        let mut builder = DirBuilder::new();
-        builder.recursive(true);
-        builder.create(self.target_dir.as_ref().unwrap())?; // if target dir can't be created, there's no good way to continue execution
-        builder.create(self.fail_dir.as_ref().unwrap())?; // if fail dir can't be created, there's no good way to continue execution
-        if is_automatic {
-            loop {
-                match self.process_all_files() {
-                    Ok(_) => {
-                        if self.verbose {
-                            println!("Finished one iteration. Sleeping until next directory scan.");
-                        }
-                    }
-                    Err(e) => eprintln!(
-                        "Iteration failed with error: {}. Sleeping until next directory scan.",
-                        e
-                    ),
-                }
-                self.ping_url();
-
-                thread::sleep(TIME_BETWEEN_DIR_SCANS);
-            }
-        } else {
-            match self.process_all_files() {
-                Ok(_) => {
-                    if self.verbose {
-                        println!("Finished.");
-                    }
-                }
-                Err(e) => eprintln!("Failed with error: {}.", e),
-            }
-
-            return Ok(());
-        }
-    }
-
-    fn process_all_files(&self) -> FnResult<()> {
-        if self.verbose {
-            println!("Scan directory");
-        }
-        // list files in both directories
-        let mut schedule_filenames = Main::read_dir_simple(&self.schedule_dir.as_ref().unwrap())?;
-        let rt_filenames = Main::read_dir_simple(&self.rt_dir.as_ref().unwrap())?;
-
-        if rt_filenames.is_empty() {
-            return Err(Box::from(SimpleError::new("No realtime data.")));
-        }
-
-        if schedule_filenames.is_empty() {
-            return Err(Box::from(SimpleError::new(
-                "No schedule data (but real time data is present).",
-            )));
-        }
-
-        // get the date of the earliest schedule, then reverse the list to start searching with the latest schedule
-        let oldest_schedule_date = Main::date_from_filename(&schedule_filenames[0])?;
-        schedule_filenames.reverse();
-
-        // data structures to collect the files to work on in the current iteration (one schedule and all its corresponding rt files)
-        let mut current_schedule_file = String::new();
-        let mut realtime_files_for_current_schedule: Vec<String> = Vec::new();
-
-        let mut schedules_count = 0;
-        let mut schedules_success_count = 0;
-        let mut real_time_files_count = 0;
-        let mut real_time_files_success_count = 0;
-        let mut trip_updates_count = 0;
-        let mut trip_updates_success_count = 0;
-        let mut stop_time_updates_count = 0;
-        let mut stop_time_updates_success_count = 0;
-
-        // Iterate over all rt files (oldest first), collecting all rt files that belong to the same schedule to process them in batch.
-        for rt_filename in rt_filenames {
-            let rt_date = match Main::date_from_filename(&rt_filename) {
-                Ok(date) => date,
-                Err(e) => {
-                    match &self.fail_dir {
-                        Some(d) => {
-                            Main::move_file_to_dir(&rt_filename, &d)?;
-                            eprintln!("Rt file {} does not contain a valid date and was moved to {}. (Error was {})", rt_filename, d, e);
-                        }
-                        None => eprintln!(
-                            "Rt file {} does not contain a valid date. (Error was {})",
-                            rt_filename, e
-                        ),
-                    }
-                    real_time_files_count += 1;
-                    continue;
-                }
-            };
-
-            if rt_date <= oldest_schedule_date {
-                eprintln!(
-                    "Realtime data {} is older than any schedule, skipping.",
-                    rt_filename
-                );
-                // Don't increment count because this is not really a problem, 
-                // and because we don't move those files into fail_dir,
-                // we would count them as an error over and over again.
-                // real_time_files_count += 1;
-                continue;
-            }
-
-            // Look at all schedules (newest first)
-            for schedule_filename in &schedule_filenames {
-                let schedule_date = match Main::date_from_filename(&schedule_filename) {
-                    Ok(date) => date,
-                    Err(e) => {
-                        match &self.fail_dir {
-                            Some(d) => {
-                                Main::move_file_to_dir(schedule_filename, &d)?;
-                                eprintln!("Schedule file {} does not contain a valid date and was moved to {}. (Error was {})", schedule_filename, d, e);
-                            }
-                            None => eprintln!(
-                                "Schedule file {} does not contain a valid date. (Error was {})",
-                                schedule_filename, e
-                            ),
-                        }
-                        continue;
-                    }
-                };
-                // Assume we found the right schedule if this is the newest schedule that is older than the realtime file:
-                if rt_date > schedule_date {
-                    // process the current schedule's collection before going to next schedule
-                    if *schedule_filename != current_schedule_file {
-                        if !realtime_files_for_current_schedule.is_empty() {
-                            schedules_count += 1;
-                            match self.process_schedule_and_realtimes(
-                                &current_schedule_file,
-                                &realtime_files_for_current_schedule,
-                            ) {
-                                Ok(((rtc, rtsc), (tuc, tusc), (stuc, stusc))) => {
-                                    schedules_success_count += 1;
-                                    real_time_files_count += rtc;
-                                    real_time_files_success_count += rtsc;
-                                    trip_updates_count += tuc;
-                                    trip_updates_success_count += tusc;
-                                    stop_time_updates_count += stuc;
-                                    stop_time_updates_success_count += stusc;
-                                }
-                                Err(e) => eprintln!(
-                                    "Error in schedule file {}: {}",
-                                    current_schedule_file, e
-                                ),
-                            };
-                        }
-                        // go on with the next schedule
-                        current_schedule_file = schedule_filename.clone();
-                        realtime_files_for_current_schedule.clear();
-                    }
-                    realtime_files_for_current_schedule.push(rt_filename.clone());
-                    // Correct schedule found for this one, so continue with next realtime file
-                    break;
-                }
-            }
-        }
-
-        // process last schedule's collection
-        if !realtime_files_for_current_schedule.is_empty() {
-            schedules_count += 1;
-            match self.process_schedule_and_realtimes(
-                &current_schedule_file,
-                &realtime_files_for_current_schedule,
-            ) {
-                Ok(((rtc, rtsc), (tuc, tusc), (stuc, stusc))) => {
-                    schedules_success_count += 1;
-                    real_time_files_count += rtc;
-                    real_time_files_success_count += rtsc;
-                    trip_updates_count += tuc;
-                    trip_updates_success_count += tusc;
-                    stop_time_updates_count += stuc;
-                    stop_time_updates_success_count += stusc;
-                }
-                Err(e) => eprintln!("Error in schedule file {}: {}", current_schedule_file, e),
-            };
-        }
-        self.output_statistics((
-            (schedules_count, schedules_success_count),
-            (real_time_files_count, real_time_files_success_count),
-            (trip_updates_count, trip_updates_success_count),
-            (stop_time_updates_count, stop_time_updates_success_count),
-        ));
-        Ok(())
-    }
-
-    /// Perform the import of one or more realtime data sets relating to a single schedule
-    fn process_schedule_and_realtimes(
-        &self,
-        gtfs_schedule_filename: &str,
-        gtfs_realtime_filenames: &Vec<String>,
-    ) -> FnResult<((u32, u32), (u32, u32), (u32, u32))> {
-        if self.verbose {
-            println!("Parsing schedule…");
-        }
-
-        let schedule = match Gtfs::new(gtfs_schedule_filename) {
-            Ok(schedule) => schedule,
-            Err(e) => {
-                match &self.fail_dir {
-                    Some(d) => {
-                        Main::move_file_to_dir(gtfs_schedule_filename, &d)?;
-                        eprintln!("Schedule file {} could not be parsed and was moved to {}. (Error was {})", gtfs_schedule_filename, d, e);
-                    }
-                    None => eprintln!(
-                        "Schedule file {} could not be parsed. (Error was {})",
-                        gtfs_schedule_filename, e
-                    ),
-                }
-                return Err(Box::from(SimpleError::new(
-                    "Schedule file could not be parsed.",
-                )));
-            }
-        };
-
-        if self.verbose {
-            println!("Importing realtime data…");
-        }
-        // create importer for this schedule and iterate over all given realtime files
-        let imp = Importer::new(&schedule, &self.pool, self.verbose, &self.source);
-
-        let (rt, tu, stu) = gtfs_realtime_filenames
-            .par_iter()
-            .map(|gtfs_realtime_filename| {
-                match self.process_realtime(&gtfs_realtime_filename, &imp) {
-                    Ok(tuple) => ((1,1), tuple.0, tuple.1),
-                    Err(e) => {
-                        eprintln!("Error while reading {}: {}", &gtfs_realtime_filename, e);
-                        ((1, 0), (0, 0), (0, 0))
-                    }
-                }
-            })
-            .reduce(
-                || ((0, 0), (0, 0), (0, 0)),
-                |a, b| {
-                    (
-                        ((a.0).0 + (b.0).0, (a.0).1 + (b.0).1),
-                        ((a.1).0 + (b.1).0, (a.1).1 + (b.1).1),
-                        ((a.2).0 + (b.2).0, (a.2).1 + (b.2).1),
-                    )
-                },
-            );
-        if self.verbose {
-            println!("Done!");
-        }
-        Ok((rt, tu, stu))
-    }
-
-    /// Process a single realtime file on the given Importer
-    fn process_realtime(
-        &self,
-        gtfs_realtime_filename: &str,
-        imp: &Importer,
-    ) -> FnResult<((u32, u32), (u32, u32))> {
-        let statistics = match imp.import_realtime_into_database(&gtfs_realtime_filename) {
-            Ok(s) => s,
-            Err(e) => {
-                // Don't print the error, because it will be handled by the calling function
-                eprintln!("Error in realtime file, moving to fail_dir…");
-                if let Some(dir) = &self.fail_dir {
-                    Main::move_file_to_dir(gtfs_realtime_filename, &dir)?;
-                }
-                return Err(e);
-            }
-        };
-        // TODO possibly make an error file per failed file to capture the error in place
-        if self.verbose {
-            println!("Finished importing file: {}", &gtfs_realtime_filename);
-        } else {
-            println!("{}", &gtfs_realtime_filename);
-        }
-        // move file into target_dir if target_dir is defined
-        if let Some(dir) = &self.target_dir {
-            Main::move_file_to_dir(gtfs_realtime_filename, &dir)?;
-        }
-        Ok(statistics)
-    }
-
-    fn move_file_to_dir(filename: &str, dir: &String) -> FnResult<()> {
-        let mut target_path = PathBuf::from(dir);
-        target_path.push(Path::new(&filename).file_name().unwrap()); // assume that the filename does not end in `..` because we got it from a directory listing
-        std::fs::rename(filename, target_path)?;
-        Ok(())
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,6 @@ pub struct Main {
     pool: Pool,
     args: ArgMatches,
     source: String,
-    schedule_dir: Option<String>,
-    rt_dir: Option<String>,
 }
 
 fn main() -> FnResult<()> {
@@ -104,8 +102,6 @@ impl Main {
             verbose,
             pool,
             source,
-            schedule_dir: None,
-            rt_dir: None,
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> FnResult<()> {
 }
 
 fn parse_args() -> ArgMatches {
-    let matches = App::new("Dystonse GTFS Tool")
+    let matches = App::new("dystonse-gtfs-data")
         .subcommand(Importer::get_subcommand())
         .subcommand(Analyser::get_subcommand())
         .arg(Arg::with_name("verbose")


### PR DESCRIPTION
This PR makes `import` a command within `dystonse-gtfs-tool` and adds a new `analyse` command (which does nothing yet).

If we change it that way, of course we should also rename the repository from `dystonse-gtfs-importer` to `dystonse-gtfs-tool` and adapt the Docker setup.